### PR TITLE
tracking individual losses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---------------------------------------------------------
 
+## [0.1.0] - 2024-02-19
+
+## Added
+
+* Added tracking for individual loss components
+
 ## [0.0.2] - 2024-02-09
 
 ## Fixed

--- a/src/physicsml/lightning/module.py
+++ b/src/physicsml/lightning/module.py
@@ -22,7 +22,7 @@ class PhysicsMLModuleBase(
         self.model_config = model_config
 
     @abstractmethod
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
         """a method to compute the loss for a model"""
 
     def compute_forces_by_gradient(
@@ -92,9 +92,9 @@ class PhysicsMLModuleBase(
         else:
             output = self(batch_dict)
 
-        loss = self.compute_loss(output, batch_dict)
+        loss_dict = self.compute_loss(output, batch_dict)
 
-        return loss, {"loss": loss}, single_source_batch.ptr.shape[0] - 1
+        return loss_dict["loss"], loss_dict, single_source_batch.ptr.shape[0] - 1
 
     def _validation_step_on_single_source_batch(
         self,
@@ -125,9 +125,9 @@ class PhysicsMLModuleBase(
         else:
             output = self(batch_dict)
 
-        loss = self.compute_loss(output, batch_dict)
+        loss_dict = self.compute_loss(output, batch_dict)
 
-        return loss, {"loss": loss}, single_source_batch.ptr.shape[0] - 1
+        return loss_dict["loss"], loss_dict, single_source_batch.ptr.shape[0] - 1
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> Any:
         """method for doing a predict step"""

--- a/src/physicsml/models/allegro/mean_var/mean_var_allegro_module.py
+++ b/src/physicsml/models/allegro/mean_var/mean_var_allegro_module.py
@@ -116,19 +116,25 @@ class PooledMeanVarAllegroModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if y_key == "y_graph_scalars":
-                total_loss += loss(
+                key_loss = loss(
                     input["y_graph_scalars"],
                     target["y_graph_scalars"],
                     input["y_graph_scalars::std"] ** 2,
                 )
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
             elif target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/allegro/supervised/allegro_module.py
+++ b/src/physicsml/models/allegro/supervised/allegro_module.py
@@ -102,13 +102,17 @@ class PooledAllegroModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/ani/mean_var/mean_var_ani_module.py
+++ b/src/physicsml/models/ani/mean_var/mean_var_ani_module.py
@@ -101,19 +101,25 @@ class PooledMeanVarANIModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if y_key == "y_graph_scalars":
-                total_loss += loss(
+                key_loss = loss(
                     input["y_graph_scalars"],
                     target["y_graph_scalars"],
                     input["y_graph_scalars::std"] ** 2,
                 )
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
             elif target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}
@@ -161,9 +167,9 @@ class PooledMeanVarANIModule(PhysicsMLModuleBase):
         else:
             output = self(single_source_batch)
 
-        loss = self.compute_loss(output, single_source_batch)
+        loss_dict = self.compute_loss(output, single_source_batch)
 
-        return loss, {"loss": loss}, single_source_batch["species"].shape[0]
+        return loss_dict["loss"], loss_dict, single_source_batch["species"].shape[0]
 
     def _validation_step_on_single_source_batch(
         self,
@@ -200,9 +206,9 @@ class PooledMeanVarANIModule(PhysicsMLModuleBase):
         else:
             output = self(single_source_batch)
 
-        loss = self.compute_loss(output, single_source_batch)
+        loss_dict = self.compute_loss(output, single_source_batch)
 
-        return loss, {"loss": loss}, single_source_batch["species"].shape[0]
+        return loss_dict["loss"], loss_dict, single_source_batch["species"].shape[0]
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> Any:
         """fit method for doing a predict step"""

--- a/src/physicsml/models/ani/supervised/ani_module.py
+++ b/src/physicsml/models/ani/supervised/ani_module.py
@@ -83,13 +83,17 @@ class PooledANIModule(PhysicsMLModuleBase):
 
         return {"y_graph_scalars": energies}
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}
@@ -145,9 +149,9 @@ class PooledANIModule(PhysicsMLModuleBase):
         else:
             output = self(single_source_batch)
 
-        loss = self.compute_loss(output, single_source_batch)
+        loss_dict = self.compute_loss(output, single_source_batch)
 
-        return loss, {"loss": loss}, single_source_batch["species"].shape[0]
+        return loss_dict["loss"], loss_dict, single_source_batch["species"].shape[0]
 
     def _validation_step_on_single_source_batch(
         self,
@@ -184,9 +188,9 @@ class PooledANIModule(PhysicsMLModuleBase):
         else:
             output = self(single_source_batch)
 
-        loss = self.compute_loss(output, single_source_batch)
+        loss_dict = self.compute_loss(output, single_source_batch)
 
-        return loss, {"loss": loss}, single_source_batch["species"].shape[0]
+        return loss_dict["loss"], loss_dict, single_source_batch["species"].shape[0]
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> Any:
         """fit method for doing a predict step"""

--- a/src/physicsml/models/egnn/adapter/adapter_egnn_module.py
+++ b/src/physicsml/models/egnn/adapter/adapter_egnn_module.py
@@ -120,13 +120,17 @@ class PooledAdapterEGNNModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/egnn/mean_var/mean_var_egnn_module.py
+++ b/src/physicsml/models/egnn/mean_var/mean_var_egnn_module.py
@@ -131,19 +131,25 @@ class PooledMeanVarEGNNModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if y_key == "y_graph_scalars":
-                total_loss += loss(
+                key_loss = loss(
                     input["y_graph_scalars"],
                     target["y_graph_scalars"],
                     input["y_graph_scalars::std"] ** 2,
                 )
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
             elif target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/egnn/ssf/ssf_egnn_module.py
+++ b/src/physicsml/models/egnn/ssf/ssf_egnn_module.py
@@ -118,13 +118,17 @@ class PooledSSFEGNNModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/egnn/supervised/egnn_module.py
+++ b/src/physicsml/models/egnn/supervised/egnn_module.py
@@ -124,13 +124,17 @@ class PooledEGNNModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/mace/adapter/adapter_mace_module.py
+++ b/src/physicsml/models/mace/adapter/adapter_mace_module.py
@@ -176,13 +176,17 @@ class PooledAdapterMACEModule(PhysicsMLModuleBase):
 
         return out
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/mace/mean_var/mean_var_mace_module.py
+++ b/src/physicsml/models/mace/mean_var/mean_var_mace_module.py
@@ -186,19 +186,25 @@ class PooledMeanVarMACEModule(PhysicsMLModuleBase):
 
         return out
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if y_key == "y_graph_scalars":
-                total_loss += loss(
+                key_loss = loss(
                     input["y_graph_scalars"],
                     target["y_graph_scalars"],
                     input["y_graph_scalars::std"] ** 2,
                 )
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
             elif target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/mace/ssf/ssf_mace_module.py
+++ b/src/physicsml/models/mace/ssf/ssf_mace_module.py
@@ -174,13 +174,17 @@ class PooledSSFMACEModule(PhysicsMLModuleBase):
 
         return out
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/mace/supervised/mace_module.py
+++ b/src/physicsml/models/mace/supervised/mace_module.py
@@ -173,13 +173,17 @@ class PooledMACEModule(PhysicsMLModuleBase):
 
         return out
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/nequip/adapter/adapter_nequip_module.py
+++ b/src/physicsml/models/nequip/adapter/adapter_nequip_module.py
@@ -129,13 +129,17 @@ class PooledAdapterNequipModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/nequip/mean_var/mean_var_nequip_module.py
+++ b/src/physicsml/models/nequip/mean_var/mean_var_nequip_module.py
@@ -141,19 +141,25 @@ class PooledMeanVarNequipModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if y_key == "y_graph_scalars":
-                total_loss += loss(
+                key_loss = loss(
                     input["y_graph_scalars"],
                     target["y_graph_scalars"],
                     input["y_graph_scalars::std"] ** 2,
                 )
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
             elif target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/nequip/ssf/ssf_nequip_module.py
+++ b/src/physicsml/models/nequip/ssf/ssf_nequip_module.py
@@ -127,13 +127,17 @@ class PooledSSFNequipModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/nequip/supervised/nequip_module.py
+++ b/src/physicsml/models/nequip/supervised/nequip_module.py
@@ -127,13 +127,17 @@ class PooledNequipModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/models/prism.py
+++ b/src/physicsml/models/prism.py
@@ -143,8 +143,8 @@ class PrismLightningBase(PhysicsMLModuleBase):
     def __init__(self) -> None:
         super().__init__(model_config=None)  # type: ignore
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
-        return torch.empty(0)
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        return {"loss": torch.empty(0)}
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> Any:
         """method for doing a predict step"""

--- a/src/physicsml/models/tensor_net/supervised/tensor_net_module.py
+++ b/src/physicsml/models/tensor_net/supervised/tensor_net_module.py
@@ -96,13 +96,17 @@ class PooledTensorNetModule(PhysicsMLModuleBase):
 
         return output
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        loss_dict: Dict[str, torch.Tensor] = {}
         total_loss: torch.Tensor = torch.zeros(1, device=self.device)
         for y_key, loss in self.losses.items():
             if target.get(y_key, None) is not None:
-                total_loss += loss(input, target)
+                key_loss = loss(input, target)
+                loss_dict[y_key] = key_loss
+                total_loss += key_loss
 
-        return total_loss
+        loss_dict["loss"] = total_loss
+        return loss_dict
 
     def configure_losses(self) -> Any:
         losses: Dict[str, Optional[Any]] = {}

--- a/src/physicsml/plugins/openmm/openmm_base.py
+++ b/src/physicsml/plugins/openmm/openmm_base.py
@@ -124,5 +124,5 @@ class OpenMMModuleBase(PhysicsMLModuleBase):
 
         return clone
 
-    def compute_loss(self, input: Any, target: Any) -> torch.Tensor:
-        return torch.empty(0)
+    def compute_loss(self, input: Any, target: Any) -> Dict[str, torch.Tensor]:
+        return {"loss": torch.empty(0)}


### PR DESCRIPTION
A PR to add tracking for individual losses (previously only total loss was tracked). 

Now returns a dict of losses from the ``compute_loss`` method and logs all of them. The loss with ``key="loss"`` is the one used for training, the remaining ones are just tracked.