### PR TITLE
Position wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Added coordinate wrapping in the neighbour list computations of ANI and graphs
+* Turn on openmm tests
 
 ## [0.2.3] - 2024-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Added coordinate wrapping in the neighbour list computations of ANI and graphs
-* Turn on openmm tests
+* Turn on openmm tests in actions
 
 ## [0.2.3] - 2024-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Added coordinate wrapping in the neighbour list computations of ANI and graphs
-* Turn on openmm tests in actions
 
 ## [0.2.3] - 2024-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ---------------------------------------------------------
+ ## [0.2.4] - 2024-04-24
+
+### Fixed
+
+* Added coordinate wrapping in the neighbour list computations of ANI and graphs
+
 ## [0.2.3] - 2024-04-09
 
 ## Changed

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,13 +21,13 @@ TEST_REPORTS_DIR = "test-reports"
 
 # all external utility tools used by our nox sessions
 BUILD_TOOLS = ["build"]
-COVERAGE_TOOLS = ["coverage[toml]", "coverage-badge"]
+COVERAGE_TOOLS = ["coverage[toml]<7.5", "coverage-badge"]
 FORMATTING_TOOLS = ["black[jupyter]~=23.0"]
 LINTING_TOOLS = ["ruff~=0.0.292"]
 LOCKFILE_TOOLS = ["pip-tools>=7.0.0"]  # default --resolver=backtracking
 
 EXTRAS = [None, "openmm", "rdkit", "ase", "openeye"]
-DONT_TEST = [None, "openeye", "openmm"]
+DONT_TEST = [None, "openeye"]
 
 def resolve_lockfile_path(python_version: str, extra: Optional[str] = None, rootdir: str = PINNED_VERSIONS) -> pathlib.Path:
     """Resolves the expected lockfile path for a given python version and extra."""
@@ -278,9 +278,12 @@ def run_tests(session: nox.Session, *args: str, extra: Optional[str], lockfile_p
     # all tests requiring the extra are in their own dir and
     tests_target_dirs = [f"tests/{extra}"]
 
-    # Run tests
     session.install(f".[{package_extras}]", "--constraint", str(lockfile_path))
 
+    if extra == "openmm":
+        session.conda_install("openmm-ml", channel=["conda-forge"])
+
+    # Run tests
     coverage_datafile_path = resolve_coverage_datafile_path(python_version=session.python, extra=extra)
     junitxml_path = resolve_junitxml_path(python_version=session.python, extra=extra)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ LINTING_TOOLS = ["ruff~=0.0.292"]
 LOCKFILE_TOOLS = ["pip-tools>=7.0.0"]  # default --resolver=backtracking
 
 EXTRAS = [None, "openmm", "rdkit", "ase", "openeye"]
-DONT_TEST = [None, "openeye"]
+DONT_TEST = [None, "openeye", "openmm"]
 
 def resolve_lockfile_path(python_version: str, extra: Optional[str] = None, rootdir: str = PINNED_VERSIONS) -> pathlib.Path:
     """Resolves the expected lockfile path for a given python version and extra."""
@@ -280,9 +280,6 @@ def run_tests(session: nox.Session, *args: str, extra: Optional[str], lockfile_p
 
     session.install(f".[{package_extras}]", "--constraint", str(lockfile_path))
 
-    if extra == "openmm":
-        session.conda_install("openmm-ml", channel=["conda-forge"])
-
     # Run tests
     coverage_datafile_path = resolve_coverage_datafile_path(python_version=session.python, extra=extra)
     junitxml_path = resolve_junitxml_path(python_version=session.python, extra=extra)
@@ -303,7 +300,7 @@ def run_tests(session: nox.Session, *args: str, extra: Optional[str], lockfile_p
         session.notify(f"coverage_report-{session.python}", [datafiles_dir])
 
 
-@nox.session(venv_backend="conda", python=SUPPORTED_PYTHON_VERSIONS)
+@nox.session(python=SUPPORTED_PYTHON_VERSIONS)
 @nox.parametrize("extra", [e for e in EXTRAS if e not in DONT_TEST])
 def tests_run_latest(session: nox.Session, extra: Optional[str]) -> None:
     """Run tests against latest available dependencies.
@@ -323,7 +320,7 @@ def tests_run_latest(session: nox.Session, extra: Optional[str]) -> None:
         run_tests(session, *session.posargs, extra=extra, lockfile_path=scratch_output_lockfile_path, notify=False)
 
 
-@nox.session(venv_backend="conda", python=SUPPORTED_PYTHON_VERSIONS)
+@nox.session(python=SUPPORTED_PYTHON_VERSIONS)
 @nox.parametrize("extra", [e for e in EXTRAS if e not in DONT_TEST])
 def tests_run_pinned(session: nox.Session, extra: Optional[str]) -> None:
     """Run tests against pinned dependencies.

--- a/pinned-versions/3.10/lockfile.ase.txt
+++ b/pinned-versions/3.10/lockfile.ase.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.10(extra='ase')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -223,15 +220,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -241,12 +236,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -274,9 +268,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -311,7 +305,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -347,16 +340,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -365,7 +356,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -396,7 +387,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -411,7 +402,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -423,7 +414,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -468,12 +459,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -489,7 +479,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -535,10 +525,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -549,7 +535,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -558,7 +545,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -579,7 +566,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -617,10 +604,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.10/lockfile.core.txt
+++ b/pinned-versions/3.10/lockfile.core.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.10(extra=None)
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -223,15 +220,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -241,12 +236,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -274,9 +268,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -311,7 +305,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -347,16 +340,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -365,7 +356,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -396,7 +387,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -411,7 +402,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -423,7 +414,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -468,12 +459,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -489,7 +479,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -535,10 +525,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -549,7 +535,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -558,7 +545,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -579,7 +566,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -617,10 +604,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.10/lockfile.openeye.txt
+++ b/pinned-versions/3.10/lockfile.openeye.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.10(extra='openeye')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -223,15 +220,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -241,12 +236,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -274,9 +268,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -311,7 +305,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 openeye-toolkits==2023.2.3
@@ -349,16 +342,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -367,7 +358,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -398,7 +389,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -413,7 +404,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -425,7 +416,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -470,12 +461,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -491,7 +481,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -537,10 +527,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -551,7 +537,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -560,7 +547,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -581,7 +568,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -619,10 +606,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.10/lockfile.openmm.txt
+++ b/pinned-versions/3.10/lockfile.openmm.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.10(extra='openmm')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -223,15 +220,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -241,12 +236,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -274,9 +268,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -311,7 +305,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -347,16 +340,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -365,7 +356,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -396,7 +387,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -411,7 +402,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -423,7 +414,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -468,12 +459,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -489,7 +479,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -535,10 +525,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -549,7 +535,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -558,7 +545,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -579,7 +566,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -617,10 +604,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.10/lockfile.rdkit.txt
+++ b/pinned-versions/3.10/lockfile.rdkit.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.10(extra='rdkit')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -223,15 +220,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -241,12 +236,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -274,9 +268,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -311,7 +305,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -347,16 +340,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -365,7 +356,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -396,7 +387,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -411,7 +402,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -423,7 +414,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -468,12 +459,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -489,7 +479,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -535,10 +525,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -549,7 +535,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -558,7 +545,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -579,7 +566,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -617,10 +604,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.11/lockfile.ase.txt
+++ b/pinned-versions/3.11/lockfile.ase.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.11(extra='ase')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -43,11 +41,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -70,17 +68,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -95,7 +93,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -131,7 +129,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -139,9 +137,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -217,15 +214,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -235,12 +230,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -268,9 +262,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -305,7 +299,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -341,16 +334,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -359,7 +350,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -390,7 +381,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -405,7 +396,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -417,7 +408,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -462,12 +453,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -483,7 +473,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -529,17 +519,13 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
     # via scikit-learn
 toml==0.10.2
     # via jupytext
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -548,7 +534,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -569,7 +555,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -606,10 +592,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.11/lockfile.core.txt
+++ b/pinned-versions/3.11/lockfile.core.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.11(extra=None)
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -43,11 +41,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -70,17 +68,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -95,7 +93,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -131,7 +129,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -139,9 +137,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -217,15 +214,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -235,12 +230,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -268,9 +262,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -305,7 +299,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -341,16 +334,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -359,7 +350,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -390,7 +381,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -405,7 +396,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -417,7 +408,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -462,12 +453,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -483,7 +473,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -529,17 +519,13 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
     # via scikit-learn
 toml==0.10.2
     # via jupytext
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -548,7 +534,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -569,7 +555,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -606,10 +592,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.11/lockfile.openeye.txt
+++ b/pinned-versions/3.11/lockfile.openeye.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.11(extra='openeye')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -43,11 +41,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -70,17 +68,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -95,7 +93,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -131,7 +129,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -139,9 +137,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -217,15 +214,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -235,12 +230,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -268,9 +262,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -305,7 +299,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 openeye-toolkits==2023.2.3
@@ -343,16 +336,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -361,7 +352,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -392,7 +383,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -407,7 +398,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -419,7 +410,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -464,12 +455,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -485,7 +475,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -531,17 +521,13 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
     # via scikit-learn
 toml==0.10.2
     # via jupytext
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -550,7 +536,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -571,7 +557,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -608,10 +594,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.11/lockfile.openmm.txt
+++ b/pinned-versions/3.11/lockfile.openmm.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.11(extra='openmm')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -43,11 +41,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -70,17 +68,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -95,7 +93,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -131,7 +129,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -139,9 +137,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -217,15 +214,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -235,12 +230,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -268,9 +262,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -305,7 +299,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -341,16 +334,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -359,7 +350,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -390,7 +381,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -405,7 +396,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -417,7 +408,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -462,12 +453,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -483,7 +473,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -529,17 +519,13 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
     # via scikit-learn
 toml==0.10.2
     # via jupytext
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -548,7 +534,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -569,7 +555,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -606,10 +592,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.11/lockfile.rdkit.txt
+++ b/pinned-versions/3.11/lockfile.rdkit.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.11(extra='rdkit')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -43,11 +41,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -70,17 +68,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -95,7 +93,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -131,7 +129,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -139,9 +137,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -217,15 +214,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -235,12 +230,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -268,9 +262,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -305,7 +299,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -341,16 +334,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -359,7 +350,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -390,7 +381,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -405,7 +396,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -417,7 +408,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -462,12 +453,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -483,7 +473,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -529,17 +519,13 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
     # via scikit-learn
 toml==0.10.2
     # via jupytext
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -548,7 +534,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -569,7 +555,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -606,10 +592,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.8/lockfile.ase.txt
+++ b/pinned-versions/3.8/lockfile.ase.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.8(extra='ase')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -49,19 +47,17 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
     #   s3transfer
 cachecontrol==0.14.0
     # via sphinx-toolbox
-cachetools==5.3.3
-    # via google-auth
 certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
@@ -78,17 +74,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.1.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -121,7 +117,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 executing==2.0.1
     # via stack-data
@@ -140,7 +136,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -148,15 +144,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-google-auth==2.29.0
-    # via
-    #   google-auth-oauthlib
-    #   tensorboard
-google-auth-oauthlib==1.0.0
-    # via tensorboard
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -179,7 +168,6 @@ importlib-metadata==4.13.0
     #   domdf-python-tools
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -241,15 +229,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==2.2.0
     # via
     #   jupytext
@@ -259,12 +245,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.7.5
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -329,11 +314,8 @@ numpy==1.24.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
-oauthlib==3.2.2
-    # via requests-oauthlib
 opt-einsum==3.3.0
     # via opt-einsum-fx
 opt-einsum-fx==0.1.4
@@ -371,16 +353,14 @@ pillow==10.3.0
     #   rdkit
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -389,18 +369,12 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
 pyarrow-hotfix==0.6
     # via datasets
-pyasn1==0.6.0
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.0
-    # via google-auth
 pydantic==1.10.15
     # via molflux
 pydata-sphinx-theme==0.14.4
@@ -426,7 +400,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via
@@ -443,7 +417,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -455,7 +429,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -468,22 +442,16 @@ requests==2.31.0
     #   huggingface-hub
     #   molflux
     #   qlient
-    #   requests-oauthlib
     #   responses
     #   sphinx
-    #   tensorboard
     #   torch-geometric
     #   torchani
-requests-oauthlib==2.0.0
-    # via google-auth-oauthlib
 responses==0.18.0
     # via evaluate
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via google-auth
 ruamel-yaml==0.18.6
     # via sphinx-toolbox
 ruamel-yaml-clib==0.2.8
@@ -572,10 +540,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.14.0
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -586,7 +550,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -595,7 +559,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -616,7 +580,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -656,14 +620,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
-    # via
-    #   sphinx-togglebutton
-    #   tensorboard
+    # via sphinx-togglebutton
 widgetsnbextension==4.0.10
     # via ipywidgets
 xxhash==3.4.1

--- a/pinned-versions/3.8/lockfile.core.txt
+++ b/pinned-versions/3.8/lockfile.core.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.8(extra=None)
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -49,19 +47,17 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
     #   s3transfer
 cachecontrol==0.14.0
     # via sphinx-toolbox
-cachetools==5.3.3
-    # via google-auth
 certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
@@ -78,17 +74,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.1.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -121,7 +117,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 executing==2.0.1
     # via stack-data
@@ -140,7 +136,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -148,15 +144,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-google-auth==2.29.0
-    # via
-    #   google-auth-oauthlib
-    #   tensorboard
-google-auth-oauthlib==1.0.0
-    # via tensorboard
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -179,7 +168,6 @@ importlib-metadata==4.13.0
     #   domdf-python-tools
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -241,15 +229,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==2.2.0
     # via
     #   jupytext
@@ -259,12 +245,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.7.5
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -329,11 +314,8 @@ numpy==1.24.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
-oauthlib==3.2.2
-    # via requests-oauthlib
 opt-einsum==3.3.0
     # via opt-einsum-fx
 opt-einsum-fx==0.1.4
@@ -371,16 +353,14 @@ pillow==10.3.0
     #   rdkit
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -389,18 +369,12 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
 pyarrow-hotfix==0.6
     # via datasets
-pyasn1==0.6.0
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.0
-    # via google-auth
 pydantic==1.10.15
     # via molflux
 pydata-sphinx-theme==0.14.4
@@ -426,7 +400,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via
@@ -443,7 +417,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -455,7 +429,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -468,22 +442,16 @@ requests==2.31.0
     #   huggingface-hub
     #   molflux
     #   qlient
-    #   requests-oauthlib
     #   responses
     #   sphinx
-    #   tensorboard
     #   torch-geometric
     #   torchani
-requests-oauthlib==2.0.0
-    # via google-auth-oauthlib
 responses==0.18.0
     # via evaluate
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via google-auth
 ruamel-yaml==0.18.6
     # via sphinx-toolbox
 ruamel-yaml-clib==0.2.8
@@ -572,10 +540,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.14.0
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -586,7 +550,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -595,7 +559,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -616,7 +580,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -656,14 +620,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
-    # via
-    #   sphinx-togglebutton
-    #   tensorboard
+    # via sphinx-togglebutton
 widgetsnbextension==4.0.10
     # via ipywidgets
 xxhash==3.4.1

--- a/pinned-versions/3.8/lockfile.openeye.txt
+++ b/pinned-versions/3.8/lockfile.openeye.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.8(extra='openeye')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -49,19 +47,17 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
     #   s3transfer
 cachecontrol==0.14.0
     # via sphinx-toolbox
-cachetools==5.3.3
-    # via google-auth
 certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
@@ -78,17 +74,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.1.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -121,7 +117,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 executing==2.0.1
     # via stack-data
@@ -140,7 +136,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -148,15 +144,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-google-auth==2.29.0
-    # via
-    #   google-auth-oauthlib
-    #   tensorboard
-google-auth-oauthlib==1.0.0
-    # via tensorboard
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -179,7 +168,6 @@ importlib-metadata==4.13.0
     #   domdf-python-tools
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -241,15 +229,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==2.2.0
     # via
     #   jupytext
@@ -259,12 +245,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.7.5
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -329,11 +314,8 @@ numpy==1.24.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
-oauthlib==3.2.2
-    # via requests-oauthlib
 openeye-toolkits==2022.2.2 ; python_version == "3.8"
     # via physicsml (pyproject.toml)
 openeye-toolkits-python3-osx-universal==2022.2.2
@@ -375,16 +357,14 @@ pillow==10.3.0
     #   rdkit
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -393,18 +373,12 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
 pyarrow-hotfix==0.6
     # via datasets
-pyasn1==0.6.0
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.0
-    # via google-auth
 pydantic==1.10.15
     # via molflux
 pydata-sphinx-theme==0.14.4
@@ -430,7 +404,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via
@@ -447,7 +421,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -459,7 +433,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -472,22 +446,16 @@ requests==2.31.0
     #   huggingface-hub
     #   molflux
     #   qlient
-    #   requests-oauthlib
     #   responses
     #   sphinx
-    #   tensorboard
     #   torch-geometric
     #   torchani
-requests-oauthlib==2.0.0
-    # via google-auth-oauthlib
 responses==0.18.0
     # via evaluate
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via google-auth
 ruamel-yaml==0.18.6
     # via sphinx-toolbox
 ruamel-yaml-clib==0.2.8
@@ -576,10 +544,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.14.0
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -590,7 +554,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -599,7 +563,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -620,7 +584,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -660,14 +624,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
-    # via
-    #   sphinx-togglebutton
-    #   tensorboard
+    # via sphinx-togglebutton
 widgetsnbextension==4.0.10
     # via ipywidgets
 xxhash==3.4.1

--- a/pinned-versions/3.8/lockfile.openmm.txt
+++ b/pinned-versions/3.8/lockfile.openmm.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.8(extra='openmm')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -49,19 +47,17 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
     #   s3transfer
 cachecontrol==0.14.0
     # via sphinx-toolbox
-cachetools==5.3.3
-    # via google-auth
 certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
@@ -78,17 +74,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.1.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -121,7 +117,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 executing==2.0.1
     # via stack-data
@@ -140,7 +136,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -148,15 +144,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-google-auth==2.29.0
-    # via
-    #   google-auth-oauthlib
-    #   tensorboard
-google-auth-oauthlib==1.0.0
-    # via tensorboard
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -179,7 +168,6 @@ importlib-metadata==4.13.0
     #   domdf-python-tools
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -241,15 +229,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==2.2.0
     # via
     #   jupytext
@@ -259,12 +245,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.7.5
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -329,11 +314,8 @@ numpy==1.24.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
-oauthlib==3.2.2
-    # via requests-oauthlib
 opt-einsum==3.3.0
     # via opt-einsum-fx
 opt-einsum-fx==0.1.4
@@ -371,16 +353,14 @@ pillow==10.3.0
     #   rdkit
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -389,18 +369,12 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
 pyarrow-hotfix==0.6
     # via datasets
-pyasn1==0.6.0
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.0
-    # via google-auth
 pydantic==1.10.15
     # via molflux
 pydata-sphinx-theme==0.14.4
@@ -426,7 +400,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via
@@ -443,7 +417,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -455,7 +429,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -468,22 +442,16 @@ requests==2.31.0
     #   huggingface-hub
     #   molflux
     #   qlient
-    #   requests-oauthlib
     #   responses
     #   sphinx
-    #   tensorboard
     #   torch-geometric
     #   torchani
-requests-oauthlib==2.0.0
-    # via google-auth-oauthlib
 responses==0.18.0
     # via evaluate
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via google-auth
 ruamel-yaml==0.18.6
     # via sphinx-toolbox
 ruamel-yaml-clib==0.2.8
@@ -572,10 +540,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.14.0
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -586,7 +550,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -595,7 +559,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -616,7 +580,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -656,14 +620,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
-    # via
-    #   sphinx-togglebutton
-    #   tensorboard
+    # via sphinx-togglebutton
 widgetsnbextension==4.0.10
     # via ipywidgets
 xxhash==3.4.1

--- a/pinned-versions/3.8/lockfile.rdkit.txt
+++ b/pinned-versions/3.8/lockfile.rdkit.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.8(extra='rdkit')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -49,19 +47,17 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
     #   s3transfer
 cachecontrol==0.14.0
     # via sphinx-toolbox
-cachetools==5.3.3
-    # via google-auth
 certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
@@ -78,17 +74,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.1.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -121,7 +117,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 executing==2.0.1
     # via stack-data
@@ -140,7 +136,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -148,15 +144,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-google-auth==2.29.0
-    # via
-    #   google-auth-oauthlib
-    #   tensorboard
-google-auth-oauthlib==1.0.0
-    # via tensorboard
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -179,7 +168,6 @@ importlib-metadata==4.13.0
     #   domdf-python-tools
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -241,15 +229,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==2.2.0
     # via
     #   jupytext
@@ -259,12 +245,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.7.5
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -329,11 +314,8 @@ numpy==1.24.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
-oauthlib==3.2.2
-    # via requests-oauthlib
 opt-einsum==3.3.0
     # via opt-einsum-fx
 opt-einsum-fx==0.1.4
@@ -371,16 +353,14 @@ pillow==10.3.0
     #   rdkit
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -389,18 +369,12 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
 pyarrow-hotfix==0.6
     # via datasets
-pyasn1==0.6.0
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.0
-    # via google-auth
 pydantic==1.10.15
     # via molflux
 pydata-sphinx-theme==0.14.4
@@ -426,7 +400,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via
@@ -443,7 +417,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -455,7 +429,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -468,22 +442,16 @@ requests==2.31.0
     #   huggingface-hub
     #   molflux
     #   qlient
-    #   requests-oauthlib
     #   responses
     #   sphinx
-    #   tensorboard
     #   torch-geometric
     #   torchani
-requests-oauthlib==2.0.0
-    # via google-auth-oauthlib
 responses==0.18.0
     # via evaluate
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via google-auth
 ruamel-yaml==0.18.6
     # via sphinx-toolbox
 ruamel-yaml-clib==0.2.8
@@ -572,10 +540,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.14.0
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -586,7 +550,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -595,7 +559,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -616,7 +580,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -656,14 +620,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
-    # via
-    #   sphinx-togglebutton
-    #   tensorboard
+    # via sphinx-togglebutton
 widgetsnbextension==4.0.10
     # via ipywidgets
 xxhash==3.4.1

--- a/pinned-versions/3.9/lockfile.ase.txt
+++ b/pinned-versions/3.9/lockfile.ase.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.9(extra='ase')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -169,7 +166,6 @@ importlib-metadata==4.13.0
     # via
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -228,15 +224,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -246,12 +240,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -279,9 +272,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -316,7 +309,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -352,16 +344,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -370,7 +360,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -401,7 +391,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -416,7 +406,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -428,7 +418,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -473,12 +463,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -494,7 +483,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -540,10 +529,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -554,7 +539,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -563,7 +549,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -584,7 +570,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -622,10 +608,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.9/lockfile.core.txt
+++ b/pinned-versions/3.9/lockfile.core.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.9(extra=None)
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -169,7 +166,6 @@ importlib-metadata==4.13.0
     # via
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -228,15 +224,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -246,12 +240,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -279,9 +272,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -316,7 +309,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -352,16 +344,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -370,7 +360,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -401,7 +391,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -416,7 +406,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -428,7 +418,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -473,12 +463,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -494,7 +483,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -540,10 +529,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -554,7 +539,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -563,7 +549,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -584,7 +570,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -622,10 +608,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.9/lockfile.openeye.txt
+++ b/pinned-versions/3.9/lockfile.openeye.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.9(extra='openeye')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -169,7 +166,6 @@ importlib-metadata==4.13.0
     # via
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -228,15 +224,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -246,12 +240,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -279,9 +272,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -316,7 +309,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 openeye-toolkits==2023.2.3
@@ -354,16 +346,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -372,7 +362,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -403,7 +393,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -418,7 +408,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -430,7 +420,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -475,12 +465,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -496,7 +485,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -542,10 +531,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -556,7 +541,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -565,7 +551,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -586,7 +572,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -624,10 +610,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.9/lockfile.openmm.txt
+++ b/pinned-versions/3.9/lockfile.openmm.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.9(extra='openmm')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -169,7 +166,6 @@ importlib-metadata==4.13.0
     # via
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -228,15 +224,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -246,12 +240,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -279,9 +272,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -316,7 +309,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -352,16 +344,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -370,7 +360,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -401,7 +391,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -416,7 +406,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -428,7 +418,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -473,12 +463,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -494,7 +483,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -540,10 +529,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -554,7 +539,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -563,7 +549,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -584,7 +570,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -622,10 +608,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pinned-versions/3.9/lockfile.rdkit.txt
+++ b/pinned-versions/3.9/lockfile.rdkit.txt
@@ -4,11 +4,9 @@
 #
 #    nox -s dependencies_pin-3.9(extra='rdkit')
 #
-absl-py==2.1.0
-    # via tensorboard
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   datasets
     #   fsspec
@@ -45,11 +43,11 @@ beautifulsoup4==4.12.3
     # via
     #   pydata-sphinx-theme
     #   sphinx-toolbox
-boto3==1.34.82
+boto3==1.34.91
     # via
     #   cloudpathlib
     #   molflux
-botocore==1.34.82
+botocore==1.34.91
     # via
     #   boto3
     #   molflux
@@ -72,17 +70,17 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage==7.4.4
+coverage==7.5.0
     # via
     #   coverage-badge
     #   physicsml (pyproject.toml)
-coverage-badge==1.1.0
+coverage-badge==1.1.1
     # via physicsml (pyproject.toml)
 cssutils==2.10.2
     # via dict2css
 cycler==0.12.1
     # via matplotlib
-datasets==2.18.0
+datasets==2.19.0
     # via
     #   evaluate
     #   molflux
@@ -97,7 +95,7 @@ dill==0.3.8
     #   datasets
     #   evaluate
     #   multiprocess
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -116,7 +114,7 @@ e3nn==0.5.1
     # via physicsml (pyproject.toml)
 evaluate==0.4.1
     # via molflux
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   ipython
     #   pytest
@@ -137,7 +135,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.2.0
+fsspec==2024.3.1
     # via
     #   datasets
     #   evaluate
@@ -145,9 +143,8 @@ fsspec==2024.2.0
     #   lightning
     #   molflux
     #   pytorch-lightning
+    #   torch
     #   torch-geometric
-grpcio==1.62.1
-    # via tensorboard
 h5py==3.11.0
     # via
     #   molflux
@@ -169,7 +166,6 @@ importlib-metadata==4.13.0
     # via
     #   jupyter-cache
     #   jupyter-client
-    #   markdown
     #   myst-nb
     #   qlient-core
     #   sphinx
@@ -228,15 +224,13 @@ kiwisolver==1.4.5
     # via matplotlib
 lark-parser==0.12.0
     # via torchani
-lightning==2.2.1
+lightning==2.2.3
     # via physicsml (pyproject.toml)
 lightning-utilities==0.11.2
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markdown==3.6
-    # via tensorboard
 markdown-it-py==3.0.0
     # via
     #   jupytext
@@ -246,12 +240,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   sphinx-jinja2-compat
-    #   werkzeug
 matplotlib==3.8.4
     # via
     #   ase
     #   physicsml (pyproject.toml)
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -279,9 +272,9 @@ multiprocess==0.70.16
     # via
     #   datasets
     #   evaluate
-myst-nb==1.0.0
+myst-nb==1.1.0
     # via physicsml (pyproject.toml)
-myst-parser==2.0.0
+myst-parser==3.0.0
     # via myst-nb
 natsort==8.4.0
     # via domdf-python-tools
@@ -316,7 +309,6 @@ numpy==1.26.4
     #   rdkit
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   torch-geometric
     #   torchmetrics
 opt-einsum==3.3.0
@@ -352,16 +344,14 @@ pillow==10.3.0
     # via
     #   matplotlib
     #   rdkit
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   apeye
     #   jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.1
-    # via tensorboard
 psutil==5.9.8
     # via
     #   ipykernel
@@ -370,7 +360,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==15.0.2
+pyarrow==16.0.0
     # via
     #   datasets
     #   molflux
@@ -401,7 +391,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
     #   molflux
     #   pandas
-pytorch-lightning==2.2.1
+pytorch-lightning==2.2.3
     # via lightning
 pytz==2024.1
     # via pandas
@@ -416,7 +406,7 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   pytorch-lightning
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -428,7 +418,7 @@ rapidfuzz==3.8.1
     # via thefuzz
 rdkit==2023.9.5
     # via physicsml (pyproject.toml)
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -473,12 +463,11 @@ six==1.16.0
     #   asttokens
     #   html5lib
     #   python-dateutil
-    #   tensorboard
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   autodocsumm
     #   myst-nb
@@ -494,7 +483,7 @@ sphinx==7.2.6
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinx-toolbox
-sphinx-autodoc-typehints==2.0.1
+sphinx-autodoc-typehints==2.1.0
     # via sphinx-toolbox
 sphinx-book-theme==1.1.2
     # via physicsml (pyproject.toml)
@@ -540,10 +529,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tenacity==8.2.3
     # via molflux
-tensorboard==2.16.2
-    # via physicsml (pyproject.toml)
-tensorboard-data-server==0.7.2
-    # via tensorboard
 thefuzz==0.22.1
     # via molflux
 threadpoolctl==3.4.0
@@ -554,7 +539,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-torch==2.0.1
+    #   sphinx
+torch==2.3.0
     # via
     #   e3nn
     #   lightning
@@ -563,7 +549,7 @@ torch==2.0.1
     #   pytorch-lightning
     #   torchani
     #   torchmetrics
-torch-geometric==2.5.2
+torch-geometric==2.5.3
     # via physicsml (pyproject.toml)
 torchani==2.2.3
     # via physicsml (pyproject.toml)
@@ -584,7 +570,7 @@ tqdm==4.66.2
     #   molflux
     #   pytorch-lightning
     #   torch-geometric
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -622,10 +608,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 webencodings==0.5.1
     # via html5lib
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via qlient
-werkzeug==3.0.2
-    # via tensorboard
 wheel==0.43.0
     # via sphinx-togglebutton
 widgetsnbextension==4.0.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     'torch-geometric>=2.5.0',
     'e3nn',
     'torchani!=2.2.4', # bug in torchani where it tries to import cuaev when not built
-    'tensorboard',
 ]
 
 [project.optional-dependencies]

--- a/src/physicsml/models/ani/ensemble/ensemble_ani_module.py
+++ b/src/physicsml/models/ani/ensemble/ensemble_ani_module.py
@@ -7,7 +7,6 @@ from molflux.modelzoo.models.lightning.module import (
     SingleBatchStepOutput,
 )
 from torchani import ANIModel
-from torchani.aev import AEVComputer
 
 from physicsml.lightning.losses.construct_loss import construct_loss
 from physicsml.lightning.module import PhysicsMLModuleBase
@@ -16,6 +15,7 @@ from physicsml.models.ani.ani_1_2_defaults import (
     ani_1_2_net_sizes_dict,
 )
 from physicsml.models.ani.ensemble.default_configs import EnsembleANIModelConfig
+from physicsml.models.ani.modules.aev import AEVComputer  # type: ignore
 
 
 def atomic_nets_to_module(net_sizes: Dict[str, Any]) -> Dict[str, torch.nn.Sequential]:

--- a/src/physicsml/models/ani/mean_var/mean_var_ani_module.py
+++ b/src/physicsml/models/ani/mean_var/mean_var_ani_module.py
@@ -7,7 +7,6 @@ from molflux.modelzoo.models.lightning.module import (
     SingleBatchStepOutput,
 )
 from torchani import ANIModel
-from torchani.aev import AEVComputer
 
 from physicsml.lightning.losses.construct_loss import construct_loss
 from physicsml.lightning.module import PhysicsMLModuleBase
@@ -16,6 +15,7 @@ from physicsml.models.ani.ani_1_2_defaults import (
     ani_1_2_net_sizes_dict,
 )
 from physicsml.models.ani.mean_var.default_configs import MeanVarANIModelConfig
+from physicsml.models.ani.modules.aev import AEVComputer  # type: ignore
 
 
 def atomic_nets_to_module(net_sizes: Dict[str, Any]) -> Dict[str, torch.nn.Sequential]:

--- a/src/physicsml/models/ani/modules/aev.py
+++ b/src/physicsml/models/ani/modules/aev.py
@@ -1,0 +1,709 @@
+# type: ignore
+# Taken from https://github.com/aiqm/torchani/blob/17204c6dccf6210753bc8c0ca4c92278b60719c9/torchani/aev.py
+import math
+import sys
+from typing import NamedTuple, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+"""
+cuaev is a part of torchani that is in development and must be installed from the repo
+directly as of 2024-03-15: https://github.com/aiqm/torchani/tree/master/torchani/cuaev
+Since physicsML installs torchani from pip, we're going to leave it out by setting
+has_cuaev=False but leaving the conditionals for switching to cuaev for future
+possibilities:
+
+
+if has_cuaev:
+    # We need to import torchani.cuaev to tell PyTorch to initialize torch.ops.cuaev
+    from torchani import cuaev  # type: ignore # noqa: F401
+else:
+    warnings.warn("cuaev not installed")
+"""
+has_cuaev = False
+
+if sys.version_info[:2] < (3, 7):
+
+    class FakeFinal:
+        def __getitem__(self, x):
+            return x
+
+    Final = FakeFinal()
+else:
+    from torch.jit import Final
+
+
+class SpeciesAEV(NamedTuple):
+    species: Tensor
+    aevs: Tensor
+
+
+def cutoff_cosine(distances: Tensor, cutoff: float) -> Tensor:
+    # assuming all elements in distances are smaller than cutoff
+    return 0.5 * torch.cos(distances * (math.pi / cutoff)) + 0.5
+
+
+def radial_terms(Rcr: float, EtaR: Tensor, ShfR: Tensor, distances: Tensor) -> Tensor:
+    """Compute the radial subAEV terms of the center atom given neighbors
+
+    This correspond to equation (3) in the `ANI paper`_. This function just
+    compute the terms. The sum in the equation is not computed.
+    The input tensor have shape (conformations, atoms, N), where ``N``
+    is the number of neighbor atoms within the cutoff radius and output
+    tensor should have shape
+    (conformations, atoms, ``self.radial_sublength()``)
+
+    .. _ANI paper:
+        http://pubs.rsc.org/en/Content/ArticleLanding/2017/SC/C6SC05720A#!divAbstract
+    """
+    distances = distances.view(-1, 1, 1)
+    fc = cutoff_cosine(distances, Rcr)
+    # Note that in the equation in the paper there is no 0.25
+    # coefficient, but in NeuroChem there is such a coefficient.
+    # We choose to be consistent with NeuroChem instead of the paper here.
+    ret = 0.25 * torch.exp(-EtaR * (distances - ShfR) ** 2) * fc
+    # At this point, ret now has shape
+    # (conformations x atoms, ?, ?) where ? depend on constants.
+    # We then should flat the last 2 dimensions to view the subAEV as a two
+    # dimensional tensor (onnx doesn't support negative indices in flatten)
+    return ret.flatten(start_dim=1)
+
+
+def angular_terms(
+    Rca: float,
+    ShfZ: Tensor,
+    EtaA: Tensor,
+    Zeta: Tensor,
+    ShfA: Tensor,
+    vectors12: Tensor,
+) -> Tensor:
+    """Compute the angular subAEV terms of the center atom given neighbor pairs.
+
+    This correspond to equation (4) in the `ANI paper`_. This function just
+    compute the terms. The sum in the equation is not computed.
+    The input tensor have shape (conformations, atoms, N), where N
+    is the number of neighbor atom pairs within the cutoff radius and
+    output tensor should have shape
+    (conformations, atoms, ``self.angular_sublength()``)
+
+    .. _ANI paper:
+        http://pubs.rsc.org/en/Content/ArticleLanding/2017/SC/C6SC05720A#!divAbstract
+    """
+    vectors12 = vectors12.view(2, -1, 3, 1, 1, 1, 1)
+    distances12 = vectors12.norm(2, dim=-5)
+    cos_angles = vectors12.prod(0).sum(1) / torch.clamp(distances12.prod(0), min=1e-10)
+    # 0.95 is multiplied to the cos values to prevent acos from returning NaN.
+    angles = torch.acos(0.95 * cos_angles)
+
+    fcj12 = cutoff_cosine(distances12, Rca)
+    factor1 = ((1 + torch.cos(angles - ShfZ)) / 2) ** Zeta
+    factor2 = torch.exp(-EtaA * (distances12.sum(0) / 2 - ShfA) ** 2)
+    ret = 2 * factor1 * factor2 * fcj12.prod(0)
+    # At this point, ret now has shape
+    # (conformations x atoms, ?, ?, ?, ?) where ? depend on constants.
+    # We then should flat the last 4 dimensions to view the subAEV as a two
+    # dimensional tensor (onnx doesn't support negative indices in flatten)
+    return ret.flatten(start_dim=1)
+
+
+def compute_shifts(cell: Tensor, pbc: Tensor, cutoff: float) -> Tensor:
+    """Compute the shifts of unit cell along the given cell vectors to make it
+    large enough to contain all pairs of neighbor atoms with PBC under
+    consideration
+
+    Arguments:
+        cell (:class:`torch.Tensor`): tensor of shape (3, 3) of the three
+        vectors defining unit cell:
+            tensor([[x1, y1, z1], [x2, y2, z2], [x3, y3, z3]])
+        cutoff (float): the cutoff inside which atoms are considered pairs
+        pbc (:class:`torch.Tensor`): boolean vector of size 3 storing
+            if pbc is enabled for that direction.
+
+    Returns:
+        :class:`torch.Tensor`: long tensor of shifts. the center cell and
+            symmetric cells are not included.
+    """
+    reciprocal_cell = cell.inverse().t()
+    inv_distances = reciprocal_cell.norm(2, -1)
+    num_repeats = torch.ceil(cutoff * inv_distances).to(torch.long)
+    num_repeats = torch.where(pbc, num_repeats, num_repeats.new_zeros(()))
+    r1 = torch.arange(1, num_repeats[0].item() + 1, device=cell.device)
+    r2 = torch.arange(1, num_repeats[1].item() + 1, device=cell.device)
+    r3 = torch.arange(1, num_repeats[2].item() + 1, device=cell.device)
+    o = torch.zeros(1, dtype=torch.long, device=cell.device)
+    return torch.cat(
+        [
+            torch.cartesian_prod(r1, r2, r3),
+            torch.cartesian_prod(r1, r2, o),
+            torch.cartesian_prod(r1, r2, -r3),
+            torch.cartesian_prod(r1, o, r3),
+            torch.cartesian_prod(r1, o, o),
+            torch.cartesian_prod(r1, o, -r3),
+            torch.cartesian_prod(r1, -r2, r3),
+            torch.cartesian_prod(r1, -r2, o),
+            torch.cartesian_prod(r1, -r2, -r3),
+            torch.cartesian_prod(o, r2, r3),
+            torch.cartesian_prod(o, r2, o),
+            torch.cartesian_prod(o, r2, -r3),
+            torch.cartesian_prod(o, o, r3),
+        ],
+    )
+
+
+def neighbor_pairs(
+    padding_mask: Tensor,
+    coordinates: Tensor,
+    cell: Tensor,
+    shifts: Tensor,
+    cutoff: float,
+) -> Tuple[Tensor, Tensor]:
+    """Compute pairs of atoms that are neighbors
+
+    Arguments:
+        padding_mask (:class:`torch.Tensor`): boolean tensor of shape
+            (molecules, atoms) for padding mask. 1 == is padding.
+        coordinates (:class:`torch.Tensor`): tensor of shape
+            (molecules, atoms, 3) for atom coordinates.
+        cell (:class:`torch.Tensor`): tensor of shape (3, 3) of the three vectors
+            defining unit cell: tensor([[x1, y1, z1], [x2, y2, z2], [x3, y3, z3]])
+        cutoff (float): the cutoff inside which atoms are considered pairs
+        shifts (:class:`torch.Tensor`): tensor of shape (?, 3) storing shifts
+    """
+    coordinates = coordinates.detach().masked_fill(padding_mask.unsqueeze(-1), math.nan)
+    cell = cell.detach()
+    num_atoms = padding_mask.shape[1]
+    num_mols = padding_mask.shape[0]
+    all_atoms = torch.arange(num_atoms, device=cell.device)
+
+    # Step 2: center cell
+    # torch.triu_indices is faster than combinations
+    p12_center = torch.triu_indices(num_atoms, num_atoms, 1, device=cell.device)
+    shifts_center = shifts.new_zeros((p12_center.shape[1], 3))
+
+    # Step 3: cells with shifts
+    # shape convention (shift index, molecule index, atom index, 3)
+    num_shifts = shifts.shape[0]
+    all_shifts = torch.arange(num_shifts, device=cell.device)
+    prod = torch.cartesian_prod(all_shifts, all_atoms, all_atoms).t()
+    shift_index = prod[0]
+    p12 = prod[1:]
+    shifts_outside = shifts.index_select(0, shift_index)
+
+    # Step 4: combine results for all cells
+    shifts_all = torch.cat([shifts_center, shifts_outside])
+    p12_all = torch.cat([p12_center, p12], dim=1)
+    shift_values = shifts_all.to(cell.dtype) @ cell
+
+    # step 5, compute distances, and find all pairs within cutoff
+    selected_coordinates = coordinates.index_select(1, p12_all.view(-1)).view(
+        num_mols,
+        2,
+        -1,
+        3,
+    )
+    distances = (
+        selected_coordinates[:, 0, ...] - selected_coordinates[:, 1, ...] + shift_values
+    ).norm(2, -1)
+    in_cutoff = (distances <= cutoff).nonzero()
+    molecule_index, pair_index = in_cutoff.unbind(1)
+    molecule_index *= num_atoms
+    atom_index12 = p12_all[:, pair_index]
+    shifts = shifts_all.index_select(0, pair_index)
+    return molecule_index + atom_index12, shifts
+
+
+def neighbor_pairs_nopbc(
+    padding_mask: Tensor,
+    coordinates: Tensor,
+    cutoff: float,
+) -> Tensor:
+    """Compute pairs of atoms that are neighbors (doesn't use PBC)
+
+    This function bypasses the calculation of shifts and duplication
+    of atoms in order to make calculations faster
+
+    Arguments:
+        padding_mask (:class:`torch.Tensor`): boolean tensor of shape
+            (molecules, atoms) for padding mask. 1 == is padding.
+        coordinates (:class:`torch.Tensor`): tensor of shape
+            (molecules, atoms, 3) for atom coordinates.
+        cutoff (float): the cutoff inside which atoms are considered pairs
+    """
+    coordinates = coordinates.detach().masked_fill(padding_mask.unsqueeze(-1), math.nan)
+    current_device = coordinates.device
+    num_atoms = padding_mask.shape[1]
+    num_mols = padding_mask.shape[0]
+    p12_all = torch.triu_indices(num_atoms, num_atoms, 1, device=current_device)
+    p12_all_flattened = p12_all.view(-1)
+
+    pair_coordinates = coordinates.index_select(1, p12_all_flattened).view(
+        num_mols,
+        2,
+        -1,
+        3,
+    )
+    distances = (pair_coordinates[:, 0, ...] - pair_coordinates[:, 1, ...]).norm(2, -1)
+    in_cutoff = (distances <= cutoff).nonzero()
+    molecule_index, pair_index = in_cutoff.unbind(1)
+    molecule_index *= num_atoms
+    atom_index12 = p12_all[:, pair_index] + molecule_index
+    return atom_index12
+
+
+def triu_index(num_species: int) -> Tensor:
+    species1, species2 = torch.triu_indices(num_species, num_species).unbind(0)
+    pair_index = torch.arange(species1.shape[0], dtype=torch.long)
+    ret = torch.zeros(num_species, num_species, dtype=torch.long)
+    ret[species1, species2] = pair_index
+    ret[species2, species1] = pair_index
+    return ret
+
+
+def cumsum_from_zero(input_: Tensor) -> Tensor:
+    cumsum = torch.zeros_like(input_)
+    torch.cumsum(input_[:-1], dim=0, out=cumsum[1:])
+    return cumsum
+
+
+def triple_by_molecule(atom_index12: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    """Input: indices for pairs of atoms that are close to each other.
+    each pair only appear once, i.e. only one of the pairs (1, 2) and
+    (2, 1) exists.
+
+    Output: indices for all central atoms and it pairs of neighbors. For
+    example, if input has pair (0, 1), (0, 2), (0, 3), (0, 4), (1, 2),
+    (1, 3), (1, 4), (2, 3), (2, 4), (3, 4), then the output would have
+    central atom 0, 1, 2, 3, 4 and for cental atom 0, its pairs of neighbors
+    are (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)
+    """
+    # convert representation from pair to central-others
+    ai1 = atom_index12.view(-1)
+    sorted_ai1, rev_indices = ai1.sort()
+
+    # sort and compute unique key
+    uniqued_central_atom_index, counts = torch.unique_consecutive(
+        sorted_ai1,
+        return_inverse=False,
+        return_counts=True,
+    )
+
+    # compute central_atom_index
+    pair_sizes = torch.div(counts * (counts - 1), 2, rounding_mode="trunc")
+    pair_indices = torch.repeat_interleave(pair_sizes)
+    central_atom_index = uniqued_central_atom_index.index_select(0, pair_indices)
+
+    # do local combinations within unique key, assuming sorted
+    m = counts.max().item() if counts.numel() > 0 else 0
+    n = pair_sizes.shape[0]
+    intra_pair_indices = (
+        torch.tril_indices(m, m, -1, device=ai1.device).unsqueeze(1).expand(-1, n, -1)
+    )
+    mask = (
+        torch.arange(intra_pair_indices.shape[2], device=ai1.device)
+        < pair_sizes.unsqueeze(1)
+    ).flatten()
+    sorted_local_index12 = intra_pair_indices.flatten(1, 2)[:, mask]
+    sorted_local_index12 += cumsum_from_zero(counts).index_select(0, pair_indices)
+
+    # unsort result from last part
+    local_index12 = rev_indices[sorted_local_index12]
+
+    # compute mapping between representation of central-other to pair
+    n = atom_index12.shape[1]
+    sign12 = ((local_index12 < n).to(torch.int8) * 2) - 1
+    return central_atom_index, local_index12 % n, sign12
+
+
+def compute_aev(
+    species: Tensor,
+    coordinates: Tensor,
+    triu_index: Tensor,
+    constants: Tuple[float, Tensor, Tensor, float, Tensor, Tensor, Tensor, Tensor],
+    sizes: Tuple[int, int, int, int, int],
+    cell_shifts: Optional[Tuple[Tensor, Tensor]],
+) -> Tensor:
+    Rcr, EtaR, ShfR, Rca, ShfZ, EtaA, Zeta, ShfA = constants
+    (
+        num_species,
+        radial_sublength,
+        radial_length,
+        angular_sublength,
+        angular_length,
+    ) = sizes
+    num_molecules = species.shape[0]
+    num_atoms = species.shape[1]
+    num_species_pairs = angular_length // angular_sublength
+    coordinates_ = coordinates
+    coordinates = coordinates_.flatten(0, 1)
+
+    # PBC calculation is bypassed if there are no shifts
+    if cell_shifts is None:
+        atom_index12 = neighbor_pairs_nopbc(species == -1, coordinates_, Rcr)
+        selected_coordinates = coordinates.index_select(0, atom_index12.view(-1)).view(
+            2,
+            -1,
+            3,
+        )
+        vec = selected_coordinates[0] - selected_coordinates[1]
+    else:
+        cell, shifts = cell_shifts
+
+        # solve pos = coefs^T @ cell
+        # pos = pos - torch.floor(coefs) @ cell
+        coefs = torch.floor(torch.matmul(coordinates_, torch.inverse(cell)))
+        wrapped_coordinates_ = coordinates_ - torch.matmul(coefs, cell)
+
+        atom_index12, shifts = neighbor_pairs(
+            species == -1,
+            wrapped_coordinates_,
+            cell,
+            shifts,
+            Rcr,
+        )
+        shifts = shifts + (
+            coefs.flatten(0, 1)[atom_index12[1]] - coefs.flatten(0, 1)[atom_index12[0]]
+        )
+
+        shift_values = shifts.to(cell.dtype) @ cell
+        selected_coordinates = coordinates.index_select(0, atom_index12.view(-1)).view(
+            2,
+            -1,
+            3,
+        )
+        vec = selected_coordinates[0] - selected_coordinates[1] + shift_values
+
+    species = species.flatten()
+    species12 = species[atom_index12]
+
+    distances = vec.norm(2, -1)
+
+    # compute radial aev
+    radial_terms_ = radial_terms(Rcr, EtaR, ShfR, distances)
+    radial_aev = radial_terms_.new_zeros(
+        (num_molecules * num_atoms * num_species, radial_sublength),
+    )
+    index12 = atom_index12 * num_species + species12.flip(0)
+    radial_aev.index_add_(0, index12[0], radial_terms_)
+    radial_aev.index_add_(0, index12[1], radial_terms_)
+    radial_aev = radial_aev.reshape(num_molecules, num_atoms, radial_length)
+
+    # Rca is usually much smaller than Rcr, using neighbor list with cutoff=Rcr is a waste of resources
+    # Now we will get a smaller neighbor list that only cares about atoms with distances <= Rca
+    even_closer_indices = (distances <= Rca).nonzero().flatten()
+    atom_index12 = atom_index12.index_select(1, even_closer_indices)
+    species12 = species12.index_select(1, even_closer_indices)
+    vec = vec.index_select(0, even_closer_indices)
+
+    # compute angular aev
+    central_atom_index, pair_index12, sign12 = triple_by_molecule(atom_index12)
+    species12_small = species12[:, pair_index12]
+    vec12 = vec.index_select(0, pair_index12.view(-1)).view(
+        2,
+        -1,
+        3,
+    ) * sign12.unsqueeze(-1)
+    species12_ = torch.where(sign12 == 1, species12_small[1], species12_small[0])
+    angular_terms_ = angular_terms(Rca, ShfZ, EtaA, Zeta, ShfA, vec12)
+    angular_aev = angular_terms_.new_zeros(
+        (num_molecules * num_atoms * num_species_pairs, angular_sublength),
+    )
+    index = (
+        central_atom_index * num_species_pairs
+        + triu_index[species12_[0], species12_[1]]
+    )
+    angular_aev.index_add_(0, index, angular_terms_)
+    angular_aev = angular_aev.reshape(num_molecules, num_atoms, angular_length)
+    return torch.cat([radial_aev, angular_aev], dim=-1)
+
+
+def jit_unused_if_no_cuaev(condition=has_cuaev):
+    def decorator(func):
+        if not condition:
+            return torch.jit.unused(func)
+        return func
+
+    return decorator
+
+
+class AEVComputer(torch.nn.Module):
+    r"""The AEV computer that takes coordinates as input and outputs aevs.
+
+    Arguments:
+        Rcr (float): :math:`R_C` in equation (2) when used at equation (3)
+            in the `ANI paper`_.
+        Rca (float): :math:`R_C` in equation (2) when used at equation (4)
+            in the `ANI paper`_.
+        EtaR (:class:`torch.Tensor`): The 1D tensor of :math:`\eta` in
+            equation (3) in the `ANI paper`_.
+        ShfR (:class:`torch.Tensor`): The 1D tensor of :math:`R_s` in
+            equation (3) in the `ANI paper`_.
+        EtaA (:class:`torch.Tensor`): The 1D tensor of :math:`\eta` in
+            equation (4) in the `ANI paper`_.
+        Zeta (:class:`torch.Tensor`): The 1D tensor of :math:`\zeta` in
+            equation (4) in the `ANI paper`_.
+        ShfA (:class:`torch.Tensor`): The 1D tensor of :math:`R_s` in
+            equation (4) in the `ANI paper`_.
+        ShfZ (:class:`torch.Tensor`): The 1D tensor of :math:`\theta_s` in
+            equation (4) in the `ANI paper`_.
+        num_species (int): Number of supported atom types.
+        use_cuda_extension (bool): Whether to use cuda extension for faster calculation (needs cuaev installed).
+
+    .. _ANI paper:
+        http://pubs.rsc.org/en/Content/ArticleLanding/2017/SC/C6SC05720A#!divAbstract
+    """
+    Rcr: Final[float]
+    Rca: Final[float]
+    num_species: Final[int]
+
+    radial_sublength: Final[int]
+    radial_length: Final[int]
+    angular_sublength: Final[int]
+    angular_length: Final[int]
+    aev_length: Final[int]
+    sizes: Final[Tuple[int, int, int, int, int]]
+    triu_index: Tensor
+    use_cuda_extension: Final[bool]
+
+    def __init__(
+        self,
+        Rcr,
+        Rca,
+        EtaR,
+        ShfR,
+        EtaA,
+        Zeta,
+        ShfA,
+        ShfZ,
+        num_species,
+        use_cuda_extension=False,
+    ):
+        super().__init__()
+        self.Rcr = Rcr
+        self.Rca = Rca
+        assert Rca <= Rcr, "Current implementation of AEVComputer assumes Rca <= Rcr"
+        self.num_species = num_species
+
+        # cuda aev
+        if use_cuda_extension:
+            assert has_cuaev, "AEV cuda extension is not installed"
+        self.use_cuda_extension = use_cuda_extension
+
+        # convert constant tensors to a ready-to-broadcast shape
+        # shape conversion (..., EtaR, ShfR)
+        self.register_buffer("EtaR", EtaR.view(-1, 1))
+        self.register_buffer("ShfR", ShfR.view(1, -1))
+        # shape conversion (..., EtaA, Zeta, ShfA, ShfZ)
+        self.register_buffer("EtaA", EtaA.view(-1, 1, 1, 1))
+        self.register_buffer("Zeta", Zeta.view(1, -1, 1, 1))
+        self.register_buffer("ShfA", ShfA.view(1, 1, -1, 1))
+        self.register_buffer("ShfZ", ShfZ.view(1, 1, 1, -1))
+
+        # The length of radial subaev of a single species
+        self.radial_sublength = self.EtaR.numel() * self.ShfR.numel()
+        # The length of full radial aev
+        self.radial_length = self.num_species * self.radial_sublength
+        # The length of angular subaev of a single species
+        self.angular_sublength = (
+            self.EtaA.numel()
+            * self.Zeta.numel()
+            * self.ShfA.numel()
+            * self.ShfZ.numel()
+        )
+        # The length of full angular aev
+        self.angular_length = (
+            (self.num_species * (self.num_species + 1)) // 2 * self.angular_sublength
+        )
+        # The length of full aev
+        self.aev_length = self.radial_length + self.angular_length
+        self.sizes = (
+            self.num_species,
+            self.radial_sublength,
+            self.radial_length,
+            self.angular_sublength,
+            self.angular_length,
+        )
+
+        self.register_buffer(
+            "triu_index",
+            triu_index(num_species).to(device=self.EtaR.device),
+        )
+
+        # Set up default cell and compute default shifts.
+        # These values are used when cell and pbc switch are not given.
+        cutoff = max(self.Rcr, self.Rca)
+        default_cell = torch.eye(3, dtype=self.EtaR.dtype, device=self.EtaR.device)
+        default_pbc = torch.zeros(3, dtype=torch.bool, device=self.EtaR.device)
+        default_shifts = compute_shifts(default_cell, default_pbc, cutoff)
+        self.register_buffer("default_cell", default_cell)
+        self.register_buffer("default_shifts", default_shifts)
+
+        # Should create only when use_cuda_extension is True.
+        # However jit needs to know cuaev_computer's Type even when use_cuda_extension is False, because it is enabled when cuaev is available
+        if has_cuaev:
+            self.init_cuaev_computer()
+        # When has_cuaev is true, and use_cuda_extension is false, and user enable use_cuda_extension afterwards,
+        # then another init_cuaev_computer will be needed
+        self.cuaev_enabled = True if self.use_cuda_extension else False
+
+    @jit_unused_if_no_cuaev()
+    def init_cuaev_computer(self):
+        self.cuaev_computer = torch.classes.cuaev.CuaevComputer(
+            self.Rcr,
+            self.Rca,
+            self.EtaR.flatten(),
+            self.ShfR.flatten(),
+            self.EtaA.flatten(),
+            self.Zeta.flatten(),
+            self.ShfA.flatten(),
+            self.ShfZ.flatten(),
+            self.num_species,
+        )
+
+    @jit_unused_if_no_cuaev()
+    def compute_cuaev(self, species, coordinates):
+        species_int = species.to(torch.int32)
+        aev = torch.ops.cuaev.run(coordinates, species_int, self.cuaev_computer)
+        return aev
+
+    @classmethod
+    def cover_linearly(
+        cls,
+        radial_cutoff: float,
+        angular_cutoff: float,
+        radial_eta: float,
+        angular_eta: float,
+        radial_dist_divisions: int,
+        angular_dist_divisions: int,
+        zeta: float,
+        angle_sections: int,
+        num_species: int,
+        angular_start: float = 0.9,
+        radial_start: float = 0.9,
+    ):
+        r"""Provides a convenient way to linearly fill cutoffs
+
+        This is a user friendly constructor that builds an
+        :class:`torchani.AEVComputer` where the subdivisions along the the
+        distance dimension for the angular and radial sub-AEVs, and the angle
+        sections for the angular sub-AEV, are linearly covered with shifts. By
+        default the distance shifts start at 0.9 Angstroms.
+
+        To reproduce the ANI-1x AEV's the signature ``(5.2, 3.5, 16.0, 8.0, 16, 4, 32.0, 8, 4)``
+        can be used.
+        """
+        # This is intended to be self documenting code that explains the way
+        # the AEV parameters for ANI1x were chosen. This is not necessarily the
+        # best or most optimal way but it is a relatively sensible default.
+        Rcr = radial_cutoff
+        Rca = angular_cutoff
+        EtaR = torch.tensor([float(radial_eta)])
+        EtaA = torch.tensor([float(angular_eta)])
+        Zeta = torch.tensor([float(zeta)])
+
+        ShfR = torch.linspace(radial_start, radial_cutoff, radial_dist_divisions + 1)[
+            :-1
+        ]
+        ShfA = torch.linspace(
+            angular_start,
+            angular_cutoff,
+            angular_dist_divisions + 1,
+        )[:-1]
+        angle_start = math.pi / (2 * angle_sections)
+
+        ShfZ = (torch.linspace(0, math.pi, angle_sections + 1) + angle_start)[:-1]
+
+        return cls(Rcr, Rca, EtaR, ShfR, EtaA, Zeta, ShfA, ShfZ, num_species)
+
+    def constants(self):
+        return (
+            self.Rcr,
+            self.EtaR,
+            self.ShfR,
+            self.Rca,
+            self.ShfZ,
+            self.EtaA,
+            self.Zeta,
+            self.ShfA,
+        )
+
+    def forward(
+        self,
+        input_: Tuple[Tensor, Tensor],
+        cell: Optional[Tensor] = None,
+        pbc: Optional[Tensor] = None,
+    ) -> SpeciesAEV:
+        """Compute AEVs
+
+        Arguments:
+            input_ (tuple): Can be one of the following two cases:
+
+                If you don't care about periodic boundary conditions at all,
+                then input can be a tuple of two tensors: species, coordinates.
+                species must have shape ``(N, A)``, coordinates must have shape
+                ``(N, A, 3)`` where ``N`` is the number of molecules in a batch,
+                and ``A`` is the number of atoms.
+
+                .. warning::
+
+                    The species must be indexed in 0, 1, 2, 3, ..., not the element
+                    index in periodic table. Check :class:`torchani.SpeciesConverter`
+                    if you want periodic table indexing.
+
+                .. note:: The coordinates, and cell are in Angstrom.
+
+                If you want to apply periodic boundary conditions, then the input
+                would be a tuple of two tensors (species, coordinates) and two keyword
+                arguments `cell=...` , and `pbc=...` where species and coordinates are
+                the same as described above, cell is a tensor of shape (3, 3) of the
+                three vectors defining unit cell:
+
+                .. code-block:: python
+
+                    tensor([[x1, y1, z1],
+                            [x2, y2, z2],
+                            [x3, y3, z3]])
+
+                and pbc is boolean vector of size 3 storing if pbc is enabled
+                for that direction.
+
+        Returns:
+            NamedTuple: Species and AEVs. species are the species from the input
+            unchanged, and AEVs is a tensor of shape ``(N, A, self.aev_length())``
+        """
+        species, coordinates = input_
+        assert species.dim() == 2
+        assert species.shape == coordinates.shape[:-1]
+        assert coordinates.shape[-1] == 3
+
+        if self.use_cuda_extension:
+            assert cell is None and pbc is None, "cuaev currently does not support PBC"
+            # if use_cuda_extension is enabled after initialization
+            if not self.cuaev_enabled:
+                self.init_cuaev_computer()
+            aev = self.compute_cuaev(species, coordinates)
+            return SpeciesAEV(species, aev)
+
+        if cell is None and pbc is None:
+            aev = compute_aev(
+                species,
+                coordinates,
+                self.triu_index,
+                self.constants(),
+                self.sizes,
+                None,
+            )
+        else:
+            assert cell is not None and pbc is not None
+            cutoff = max(self.Rcr, self.Rca)
+            shifts = compute_shifts(cell, pbc, cutoff)
+            aev = compute_aev(
+                species,
+                coordinates,
+                self.triu_index,
+                self.constants(),
+                self.sizes,
+                (cell, shifts),
+            )
+
+        return SpeciesAEV(species, aev)

--- a/src/physicsml/models/ani/supervised/ani_module.py
+++ b/src/physicsml/models/ani/supervised/ani_module.py
@@ -7,7 +7,6 @@ from molflux.modelzoo.models.lightning.module import (
     SingleBatchStepOutput,
 )
 from torchani import ANIModel
-from torchani.aev import AEVComputer
 
 from physicsml.lightning.losses.construct_loss import construct_loss
 from physicsml.lightning.module import PhysicsMLModuleBase
@@ -15,6 +14,7 @@ from physicsml.models.ani.ani_1_2_defaults import (
     ani_1_2_aev_configs,
     ani_1_2_net_sizes_dict,
 )
+from physicsml.models.ani.modules.aev import AEVComputer  # type: ignore
 from physicsml.models.ani.supervised.default_configs import ANIModelConfig
 
 

--- a/src/physicsml/models/tensor_net/modules/embedding.py
+++ b/src/physicsml/models/tensor_net/modules/embedding.py
@@ -27,7 +27,7 @@ class RadialEmbedding(torch.nn.Module):
         self.register_buffer("beta_k", beta_k.unsqueeze(0))
 
     def forward(self, r_ji: torch.Tensor) -> torch.Tensor:
-        rbf = torch.exp(-self.beta_k * (torch.exp(-r_ji) - self.mu_k) ** 2)  # type: ignore
+        rbf = torch.exp(-self.beta_k * (torch.exp(-r_ji) - self.mu_k) ** 2)
         return rbf
 
 


### PR DESCRIPTION
PR to fix PBC neighbourlists:

NL only work up to cell_size + cut_off. This PR adds coordinate wrapping to fix this. Coords are wrapped before being given to the neighbour lists and then the cell shift vector is modified (to take account of the wrapping) so that the original coordinates can still be used and any downstream distance computation remains valid with the original coordinates.